### PR TITLE
Quick fix blog post header image with inline CSS

### DIFF
--- a/blog/templates/blog/introducing-sparrow.html
+++ b/blog/templates/blog/introducing-sparrow.html
@@ -80,7 +80,7 @@
       </div>
     </nav>
 
-  <div class="blog-post-3-hero">
+  <div class="blog-post-3-hero" style="background-image: url({% static 'home/images/unsplash/twitter-header-reading.png' %});">
     <div class="container">
       <h1 class="customFadeInUp mx-auto">
         Introducing Sparrow


### PR DESCRIPTION
It seems the reason that the background from the SCSS file is being ignored might be because it seems it isn't using the output from it. I do not know whether the modified one is saved somewhere other than the modified one